### PR TITLE
devices/dmi: value was left uninitialized in one switch case

### DIFF
--- a/modules/devices/dmi.c
+++ b/modules/devices/dmi.c
@@ -102,8 +102,9 @@ gboolean dmi_get_info(void)
                     state = (getuid() == 0) ? 0 : 1;
                     break;
                 case -1:
-		  state = 2;
-		    break;
+                    state = 2;
+                    value = dmi_get_str_abs(info->id_str);
+                    break;
                 case 1:
                     value = dmi_get_str_abs(info->id_str);
                     break;


### PR DESCRIPTION
This PR fixes uninitialized variable for dmi data value.
I have one machine where this issue was causing crash on startup. 