### PR TITLE
fix desktop file

### DIFF
--- a/hardinfo2.desktop.cmake
+++ b/hardinfo2.desktop.cmake
@@ -8,5 +8,5 @@ Icon=hardinfo2
 Terminal=false
 Type=Application
 StartupNotify=true
-Categories=System;Utilities;
+Categories=System;Utility;
 Keywords=linux;kernel;system;hardware;cpu;processor;capabilities;frequency;memory;ram;board;resources;sensors;devices;usb;pci;display;network;benchmark;test;


### PR DESCRIPTION
```bash
❯ desktop-file-validate hardinfo2.desktop.cmake
hardinfo2.desktop.cmake: error: value "System;Utilities;" for key "Categories" in group "Desktop Entry" contains an unregistered value "Utilities"; values extending the format should start with "X-"
hardinfo2.desktop.cmake: error: filename does not have a .desktop extension

hardinfo2 on  master via △ v3.28.3 took 6s 
❯ nano hardinfo2.desktop.cmake

hardinfo2 on  master [!] via △ v3.28.3 took 18s 
❯ desktop-file-validate hardinfo2.desktop.cmake
hardinfo2.desktop.cmake: hint: value "System;Utility;" for key "Categories" in group "Desktop Entry" contains more than one main category; application might appear more than once in the application menu
hardinfo2.desktop.cmake: error: filename does not have a .desktop extension

hardinfo2 on  master [!] via △ v3.28.3 
❯ git diff
diff --git a/hardinfo2.desktop.cmake b/hardinfo2.desktop.cmake
index ea8329b..d6706c4 100644
--- a/hardinfo2.desktop.cmake
+++ b/hardinfo2.desktop.cmake
@@ -8,5 +8,5 @@ Icon=hardinfo2
 Terminal=false
 Type=Application
 StartupNotify=true
-Categories=System;Utilities;
+Categories=System;Utility;
 Keywords=linux;kernel;system;hardware;cpu;processor;capabilities;frequency;memory;ram;board;resources;sensors;devices;usb;pci;display;network;benchmark;test;
```