### PR TITLE
Fix 2 code writing errors for loongarch64

### DIFF
--- a/modules/devices/loongarch64/processor.c
+++ b/modules/devices/loongarch64/processor.c
@@ -53,7 +53,7 @@ processor_scan(void)
 
     fclose(cpuinfo);
 
-    return g_slist_append(NULL, processor);q
+    return g_slist_append(NULL, processor);
 }
 
 gchar *processor_name(GSList * processors) {
@@ -64,11 +64,11 @@ gchar *processor_name(GSList * processors) {
 
     if (compat != NULL) {
         //FIXME - Add table for incoming compatible DT info
-        ret= g_strdup_printf("Loongarch64 Processor (%s/%s)",processor_name_default(processors), compat);
+        ret = g_strdup_printf("Loongarch64 Processor (%s/%s)",processor_name_default(processors), compat);
         g_free(compat);
     }
 
-    if(!ret) ret=g_strdup("Loongarch64 Processor (%s/NoDT)",processor_name_default_(processors));
+    if(!ret) ret = g_strdup("Loongarch64 Processor (%s/NoDT)");
     return ret;
 }
 


### PR DESCRIPTION
Hi maintainers,

Compiling the hardinfo failed for loong64 in the Debian Package Auto-Building environment.
The build error log is as follows,
```
......
/<<PKGBUILDDIR>>/modules/devices/loongarch64/processor.c:56:44: error: ‘q’ undeclared (first use in this function)
   56 |     return g_slist_append(NULL, processor);q
      |                                            ^
/<<PKGBUILDDIR>>/modules/devices/loongarch64/processor.c:56:44: note: each undeclared identifier is reported only once for each function it appears in
/<<PKGBUILDDIR>>/modules/devices/loongarch64/processor.c:56:45: error: expected ‘;’ before ‘}’ token
   56 |     return g_slist_append(NULL, processor);q
      |                                             ^
      |                                             ;
   57 | }
......
/usr/include/glib-2.0/glib/gstrfuncs.h:324:9: note: macro "g_strdup" defined here
  324 | #define g_strdup(x) g_strdup_inline (x)
      |         ^~~~~~~~
/<<PKGBUILDDIR>>/modules/devices/loongarch64/processor.c:71:17: error: assignment to ‘gchar *’ {aka ‘char *’} from incompatible pointer type ‘gchar * (*)(const gchar *)’ {aka ‘char * (*)(const char *)’} [-Wincompatible-pointer-types]
   71 |     if(!ret) ret=g_strdup("Loongarch64 Processor (%s/NoDT)",processor_name_default_(processors));
      |                 ^
......
```
The full log can be found at https://buildd.debian.org/status/fetch.php?pkg=hardinfo&arch=loong64&ver=2.2.1-1&stamp=1730360209&raw=0.

After investigation, I found that there were coding errors in the upstream since release-2.1.16pre version.
I have fixed above 2 code writing errors on loong64.
I have built hardinfo 2.2.1-1 successfully in my local ENV. 
```
......
   dh_builddeb -O--buildsystem=cmake
dpkg-deb: building package 'hardinfo' in '../hardinfo_2.2.1-1+loong64_all.deb'.
dpkg-deb: building package 'hardinfo2' in '../hardinfo2_2.2.1-1+loong64_loong64.deb'.
dpkg-deb: building package 'hardinfo2-dbgsym' in '../hardinfo2-dbgsym_2.2.1-1+loong64_loong64.deb'.
 dpkg-genbuildinfo -O../hardinfo_2.2.1-1+loong64_loong64.buildinfo
 dpkg-genchanges -O../hardinfo_2.2.1-1+loong64_loong64.changes
```
Please review.