### PR TITLE
Explicitly declare function parameters for GCC 15 compatibility

### DIFF
--- a/includes/report.h
+++ b/includes/report.h
@@ -80,7 +80,7 @@ struct _ReportDialog {
   GtkTreeModel *model;
 };
 
-void		 report_dialog_show();
+void		 report_dialog_show(GtkTreeModel *model, GtkWidget *parent);
 
 ReportContext	*report_context_html_new();
 ReportContext	*report_context_text_new();

--- a/includes/shell.h
+++ b/includes/shell.h
@@ -163,7 +163,7 @@ struct _ShellModuleEntry {
     guint32		 flags;
 
     gchar		*(*func) ();
-    void		(*scan_func) ();
+    void		(*scan_func) (gboolean flag);
 
     gchar		*(*fieldfunc) (gchar * entry);
     gchar 		*(*morefunc)  (gchar * entry);


### PR DESCRIPTION
In GCC 15, where C23 is the default, void foo() is equivalent to void foo(void). Therefore, functions must explicitly declare their parameters.
```
/tmp/hardinfo2/hardinfo2/util.c: In function 'module_entry_reload':
/tmp/hardinfo2/hardinfo2/util.c:889:9: error: too many arguments to function 'module_entry->scan_func'
  889 |         module_entry->scan_func(TRUE);
      |         ^~~~~~~~~~~~
```
```
/tmp/hardinfo2/shell/callbacks.c: In function 'cb_generate_report':
/tmp/hardinfo2/shell/callbacks.c:489:5: error: too many arguments to function 'report_dialog_show'
  489 |     report_dialog_show(shell->tree->model, shell->window);
      |     ^~~~~~~~~~~~~~~~~~
In file included from /tmp/hardinfo2/shell/callbacks.c:30:
/tmp/hardinfo2/includes/report.h:83:18: note: declared here
   83 | void             report_dialog_show();
      |                  ^~~~~~~~~~~~~~~~~~
```
