### PR TITLE
Fix typo in DMI messages: replace “avaliable” with “available”

### DIFF
--- a/modules/devices/dmi.c
+++ b/modules/devices/dmi.c
@@ -159,7 +159,7 @@ void __scan_dmi(void)
 
   if (!dmi_ok) {
     dmi_info = g_strdup_printf("[%s]\n%s=\n",_("DMI Unavailable"),
-               _("DMI is not avaliable. Perhaps this platform does not provide DMI."));
+               _("DMI is not available. Perhaps this platform does not provide DMI."));
 
   }
 }

--- a/po/da.po
+++ b/po/da.po
@@ -3257,7 +3257,7 @@ msgid "DMI Unavailable"
 msgstr "DMI ikke tilgængelig"
 
 #: modules/devices/dmi.c:162
-msgid "DMI is not avaliable. Perhaps this platform does not provide DMI."
+msgid "DMI is not available. Perhaps this platform does not provide DMI."
 msgstr "DMI er ikke tilgængelig."
 
 #: modules/devices/dmi_memory.c:620 modules/devices/dmi_memory.c:859

--- a/po/de.po
+++ b/po/de.po
@@ -3180,7 +3180,7 @@ msgid "DMI Unavailable"
 msgstr "DMI nicht verfügbar"
 
 #: modules/devices/dmi.c:162
-msgid "DMI is not avaliable. Perhaps this platform does not provide DMI."
+msgid "DMI is not available. Perhaps this platform does not provide DMI."
 msgstr ""
 "DMI ist nicht verfügbar. Vielleicht stellt diese Plattform DMI nicht bereit."
 

--- a/po/es.po
+++ b/po/es.po
@@ -3195,7 +3195,7 @@ msgid "DMI Unavailable"
 msgstr "DMI no disponible"
 
 #: modules/devices/dmi.c:162
-msgid "DMI is not avaliable. Perhaps this platform does not provide DMI."
+msgid "DMI is not available. Perhaps this platform does not provide DMI."
 msgstr "DMI no está disponible. Puede que esta plataforma no proporcione DMI."
 
 #: modules/devices/dmi_memory.c:620 modules/devices/dmi_memory.c:859

--- a/po/fr.po
+++ b/po/fr.po
@@ -3172,7 +3172,7 @@ msgid "DMI Unavailable"
 msgstr ""
 
 #: modules/devices/dmi.c:162
-msgid "DMI is not avaliable. Perhaps this platform does not provide DMI."
+msgid "DMI is not available. Perhaps this platform does not provide DMI."
 msgstr ""
 
 #: modules/devices/dmi_memory.c:620 modules/devices/dmi_memory.c:859

--- a/po/hardinfo2.pot
+++ b/po/hardinfo2.pot
@@ -3186,7 +3186,7 @@ msgid "DMI Unavailable"
 msgstr ""
 
 #: modules/devices/dmi.c:162
-msgid "DMI is not avaliable. Perhaps this platform does not provide DMI."
+msgid "DMI is not available. Perhaps this platform does not provide DMI."
 msgstr ""
 
 #: modules/devices/dmi_memory.c:620 modules/devices/dmi_memory.c:859

--- a/po/hu.po
+++ b/po/hu.po
@@ -3153,7 +3153,7 @@ msgid "DMI Unavailable"
 msgstr "DMI nem elérhető"
 
 #: modules/devices/dmi.c:162
-msgid "DMI is not avaliable. Perhaps this platform does not provide DMI."
+msgid "DMI is not available. Perhaps this platform does not provide DMI."
 msgstr ""
 
 #: modules/devices/dmi_memory.c:620 modules/devices/dmi_memory.c:859

--- a/po/ko.po
+++ b/po/ko.po
@@ -3165,7 +3165,7 @@ msgid "DMI Unavailable"
 msgstr "DMI를 사용할 수 없음"
 
 #: modules/devices/dmi.c:162
-msgid "DMI is not avaliable. Perhaps this platform does not provide DMI."
+msgid "DMI is not available. Perhaps this platform does not provide DMI."
 msgstr "DMI를 사용할 수 없습니다. 아마도 이 플랫폼은 DMI를 제공하지 않습니다."
 
 #: modules/devices/dmi_memory.c:620 modules/devices/dmi_memory.c:859

--- a/po/pt.po
+++ b/po/pt.po
@@ -3181,7 +3181,7 @@ msgid "DMI Unavailable"
 msgstr "DMI indisponível"
 
 #: modules/devices/dmi.c:162
-msgid "DMI is not avaliable. Perhaps this platform does not provide DMI."
+msgid "DMI is not available. Perhaps this platform does not provide DMI."
 msgstr "O DMI não está disponível. Talvez esta plataforma não fornece DMI."
 
 #: modules/devices/dmi_memory.c:620 modules/devices/dmi_memory.c:859

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -3190,7 +3190,7 @@ msgid "DMI Unavailable"
 msgstr ""
 
 #: modules/devices/dmi.c:162
-msgid "DMI is not avaliable. Perhaps this platform does not provide DMI."
+msgid "DMI is not available. Perhaps this platform does not provide DMI."
 msgstr ""
 
 #: modules/devices/dmi_memory.c:620 modules/devices/dmi_memory.c:859

--- a/po/ru.po
+++ b/po/ru.po
@@ -3322,7 +3322,7 @@ msgid "DMI Unavailable"
 msgstr "DMI недоступен"
 
 #: modules/devices/dmi.c:162
-msgid "DMI is not avaliable. Perhaps this platform does not provide DMI."
+msgid "DMI is not available. Perhaps this platform does not provide DMI."
 msgstr "DMI недоступен. Возможно, эта платформа не предоставляет DMI."
 
 #: modules/devices/dmi_memory.c:620 modules/devices/dmi_memory.c:859

--- a/po/tr.po
+++ b/po/tr.po
@@ -3182,7 +3182,7 @@ msgid "DMI Unavailable"
 msgstr "DMI Kullanılamıyor"
 
 #: modules/devices/dmi.c:162
-msgid "DMI is not avaliable. Perhaps this platform does not provide DMI."
+msgid "DMI is not available. Perhaps this platform does not provide DMI."
 msgstr "DMI mevcut değildir. Belki de bu platform DMI sağlamaz."
 
 #: modules/devices/dmi_memory.c:620 modules/devices/dmi_memory.c:859

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -3125,7 +3125,7 @@ msgid "DMI Unavailable"
 msgstr ""
 
 #: modules/devices/dmi.c:162
-msgid "DMI is not avaliable. Perhaps this platform does not provide DMI."
+msgid "DMI is not available. Perhaps this platform does not provide DMI."
 msgstr ""
 
 #: modules/devices/dmi_memory.c:620 modules/devices/dmi_memory.c:859


### PR DESCRIPTION
This commit corrects a typo in the DMI-related messages across multiple files and translations. The word "avaliable" has been replaced with the correct spelling "available" in the following locations:

Source Code: Updated the DMI message in ``modules/devices/dmi.c`` to reflect the corrected text.
Translation Files: Updated corresponding translations in several .po files, including:

- da.po (Danish)
- de.po (German)
- es.po (Spanish)
- fr.po (French)
- hu.po (Hungarian)
- ko.po (Korean)
- pt.po (Portuguese)
- pt_BR.po (Brazilian Portuguese)
- ru.po (Russian)
- tr.po (Turkish)
- zh_CN.po (Simplified Chinese)
- hardinfo2.pot (Translation template)

These changes ensure consistent and professional messaging in the application and improve clarity for users across all supported languages.