### PR TITLE
FIX add single user access to extra information - RFC

### DIFF
--- a/tools/hwinfo2_fetch_sysdata
+++ b/tools/hwinfo2_fetch_sysdata
@@ -6,7 +6,7 @@ addgroup hardinfo2 2>/dev/null
 
 #Create runtime data directory
 mkdir /run/hardinfo2 2>/dev/null
-
+chmod 750 /run/hardinfo2
 
 #----Allow users in hardinfo2 group to get these hardware info----
 #iomem and ioport address - no need to show system/kernel addresses.
@@ -28,7 +28,6 @@ else
     chown -R root:hardinfo2 /run/hardinfo2
 fi
 #set rights
-chmod 750 /run/hardinfo2
 chmod 640 /run/hardinfo2/*
 
 

--- a/tools/hwinfo2_fetch_sysdata
+++ b/tools/hwinfo2_fetch_sysdata
@@ -17,9 +17,17 @@ cat /proc/ioports >/run/hardinfo2/ioports 2>/dev/null
 dmidecode -t 16 >/run/hardinfo2/dmi_memarray 2>/dev/null
 dmidecode -t 17 >/run/hardinfo2/dmi_memory 2>/dev/null
 
-
+#Allow for single user systems to use user group (To avoid reboot)
+if id -u 1000 1>/dev/null 2>/dev/null && ! id -u 1001 1>/dev/null 2>/dev/null && id -nG 1000 2>/dev/null | grep -qw $(id -un 1000); then
+    echo "Single User System" >/run/hardinfo2/log
+    #set owner to single user
+    chown -R root:$(id -un 1000) /run/hardinfo2
+else
+    echo "Multi user system / root only systems" >/run/hardinfo2/log
+    #set owner to hardinfo2 (multiuser)
+    chown -R root:hardinfo2 /run/hardinfo2
+fi
 #set rights
-chown -R root:hardinfo2 /run/hardinfo2
 chmod 750 /run/hardinfo2
 chmod 640 /run/hardinfo2/*
 


### PR DESCRIPTION
The hwinfo2_fetch_sysdata service script allows the program to have access to extra information: dmi_memarray
dmi_memory
iomem (Minus sys/kernel info)
ioports

This info is protected by group hardinfo2, which the users has to add them self to - in order to avoid leakage of information to other users.

Issue: Groups in Linux are only updated when the PC reboots, so it is kind of a hassle for 99% of users.

On a Single User system - this seams to be overkill - so this patch checks if user id 1000 exists and not 1001 to identify single user systems.

When a single user system is found the access is granted to the users instead of the hardinfo2 group.

Hence: No reboot is required and info is only available to user - nobody has no rights to extra info.