### PR TITLE
Get SPD information from udev (if available)

### DIFF
--- a/includes/spd-decode.h
+++ b/includes/spd-decode.h
@@ -84,7 +84,7 @@ typedef struct {
     gboolean ddr4_no_ee1004;
     int match_score;
     const char *spd_driver;//link to static const
-    char *vendor_str;//links to static const
+    const char *vendor_str;//links to static const
     char *dram_vendor_str;//links to static const
     struct dmi_mem_socket *dmi_socket;//links
     const Vendor *vendor;//links


### PR DESCRIPTION
This gets SPD information from udev.  It's not perfect (it doesn't get as much information as specialized modules, such as the eeprom kernel modules and such), but it doesn't require any setup.  I don't intend to continue working on this, but an improvement would be trying to merge information from both sources.