### PR TITLE
Update wayland.c to fix incorrect include on Alpine

### DIFF
--- a/deps/vkgears/wsi/wayland.c
+++ b/deps/vkgears/wsi/wayland.c
@@ -25,7 +25,7 @@
  */
 
 #include <stdint.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <wayland-client-core.h>
 #include <wayland-client-protocol.h>
 #include <wayland-client.h>

--- a/deps/vkgears/wsi/wayland.c
+++ b/deps/vkgears/wsi/wayland.c
@@ -25,7 +25,6 @@
  */
 
 #include <stdint.h>
-#include <poll.h>
 #include <wayland-client-core.h>
 #include <wayland-client-protocol.h>
 #include <wayland-client.h>


### PR DESCRIPTION
Building for Alpine Linux produces the following warning.

```
In file included from /tmp/src/hardinfo2-release-2.2.13/deps/vkgears/wsi/wayland.c:28:
/usr/include/sys/poll.h:1:2: warning: #warning redirecting incorrect #include <sys/poll.h> to <poll.h> [-Wcpp]
    1 | #warning redirecting incorrect #include <sys/poll.h> to <poll.h>
      |  ^~~~~~~
```

Does this still build on other OSs?