### PR TITLE
Only create group if it doesn't exist

### DIFF
--- a/tools/hwinfo2_fetch_sysdata
+++ b/tools/hwinfo2_fetch_sysdata
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #create group hardinfo2 if not exists
-if ! getent group hardinfo2 >/dev/null; then
+if ! awk -F: '$1 == "hardinfo2" { found = 1 } END { exit !found }' /etc/group; then
     groupadd hardinfo2 2>/dev/null
     addgroup hardinfo2 2>/dev/null
 fi

--- a/tools/hwinfo2_fetch_sysdata
+++ b/tools/hwinfo2_fetch_sysdata
@@ -1,8 +1,10 @@
 #!/bin/sh
 
 #create group hardinfo2 if not exists
-groupadd hardinfo2 2>/dev/null
-addgroup hardinfo2 2>/dev/null
+if ! getent group hardinfo2 >/dev/null; then
+    groupadd hardinfo2 2>/dev/null
+    addgroup hardinfo2 2>/dev/null
+fi
 
 #Create runtime data directory
 mkdir /run/hardinfo2 2>/dev/null


### PR DESCRIPTION
I had a "The group `hardinfo2' already exists." logged to my logs on every reboot. I have found the cause to be this script, which is called by a systemd service.

Not sure why using 2>/dev/null did not suppress this error, but this change fixes it.