### PR TITLE
TRANSLATE fix grep warnings in updatepo.sh

### DIFF
--- a/po/updatepo.sh
+++ b/po/updatepo.sh
@@ -37,11 +37,10 @@ echo "(as of $GITVER $GITHASH)"
 
 for f in *.po
 do
-    
     msgmerge -q -N "$f" hardinfo2.pot > tmp.po
 
     # set/reset the X-Poedit-Basepath header
-    grep -v '"X-Poedit-Basepath\:[^"]*"' tmp.po | sed 's:\("Language\:[^"]*"\):\1\n"X-Poedit-Basepath\: ../\\n":' >"$f"
+    grep -v '"X-Poedit-Basepath:[^"]*"' tmp.po | sed 's|\("Language:[^"]*"\)|\1\n"X-Poedit-Basepath: ../\\n"|' >"$f"
 
     rm -f tmp.po
 


### PR DESCRIPTION
fix warning `grep: warning: stray \ before :`