### PR TITLE
FIX opengl benchmark run twice when qgears2 prints addtional text

### DIFF
--- a/modules/benchmark/opengl.c
+++ b/modules/benchmark/opengl.c
@@ -33,7 +33,7 @@ static bench_value opengl_bench(int opengl, int darkmode) {
     int count, ms,ver,gl;
     float fps;
     char *cmd_line;
-    
+
     if(opengl) {
         cmd_line=g_strdup_printf("%s/modules/qgears2 -gl %s",params.path_lib, (darkmode ? "-dark" : ""));
     } else {
@@ -42,13 +42,17 @@ static bench_value opengl_bench(int opengl, int darkmode) {
 
     spawned = g_spawn_command_line_sync(cmd_line, &out, &err, NULL, NULL);
     g_free(cmd_line);
-    if (spawned && (sscanf(out,"Ver=%d, GL=%d, Result:%d/%d=%f", &ver, &gl, &count, &ms, &fps)==5)) {
-            strncpy(ret.extra, out, sizeof(ret.extra)-1);
-	    ret.extra[sizeof(ret.extra)-1]=0;
+    if (spawned && out) {
+        // Find "Ver=" to parse real benchmark info
+        char *ver_pos = strstr(out, "Ver=");
+        if (ver_pos && (sscanf(ver_pos,"Ver=%d, GL=%d, Result:%d/%d=%f", &ver, &gl, &count, &ms, &fps)==5)) {
+            strncpy(ret.extra, ver_pos, sizeof(ret.extra)-1);
+            ret.extra[sizeof(ret.extra)-1]=0;
             ret.threads_used = 1;
             ret.elapsed_time = (double)ms/1000;
-	    ret.revision = (BENCH_REVISION*100) + ver;
+            ret.revision = (BENCH_REVISION*100) + ver;
             ret.result = fps;
+        }
     }
     g_free(out);
     g_free(err);
@@ -67,6 +71,6 @@ void benchmark_opengl(void) {
     if(r.threads_used!=1) {
         r = opengl_bench(0,(params.max_bench_results==1?1:0));
     }
-    
+
     bench_results[BENCHMARK_OPENGL] = r;
 }


### PR DESCRIPTION
sometimes opengl benchmark fails due to addational text at first time, so we need to parse stdout and ignore these text

```
$ /usr/lib64/hardinfo2/modules/qgears2 -gl 2>/dev/null                                                                      on git:master| o
 not find "/dev/ftg340" 
Ver=1, GL=1, Result:7628/4000=1907.000
```