### PR TITLE
FIX memory leaks and double-free found by ASAN

### DIFF
--- a/hardinfo2/vendor.c
+++ b/hardinfo2/vendor.c
@@ -187,7 +187,7 @@ void vendor_init(void)
     };
 
     se1.name = N_("Check Update Version");
-    se1.file_name = g_strdup_printf("blobs-update-version.json");
+    se1.file_name = "blobs-update-version.json";
     se1.optional=FALSE;
 
     /* already initialized */

--- a/includes/computer.h
+++ b/includes/computer.h
@@ -150,6 +150,7 @@ extern gchar *module_list;
 gchar *computer_get_formatted_loadavg();
 gchar *computer_get_formatted_uptime();
 gchar *computer_get_alsacards(Computer * computer);
+void alsa_card_free(AlsaCard *ac);
 gchar *computer_get_entropy_avail(void);
 gchar *computer_get_aslr(void);
 gchar *computer_get_dmesg_status(void);

--- a/modules/benchmark/sysbench.c
+++ b/modules/benchmark/sysbench.c
@@ -170,6 +170,10 @@ static gboolean sysbench_run(struct sysbench_ctx *ctx, int expecting_version) {
         }
         g_free(out);
         g_free(err);
+        /* Prevent double-free: the goto sysbench_failed below
+         * also frees out/err; g_free does not NULL its argument. */
+        out = NULL;
+        err = NULL;
     } else {
     }
 

--- a/modules/computer.c
+++ b/modules/computer.c
@@ -1275,7 +1275,7 @@ void hi_module_deinit(void)
     computer_free_display(computer->display);
 
     if (computer->alsa) {
-        g_slist_free(computer->alsa->cards);
+        g_slist_free_full(computer->alsa->cards, (GDestroyNotify)alsa_card_free);
         g_free(computer->alsa);
     }
 

--- a/modules/computer/alsa.c
+++ b/modules/computer/alsa.c
@@ -69,3 +69,11 @@ computer_get_alsainfo(void)
 
     return ai;
 }
+
+void alsa_card_free(AlsaCard *ac) {
+    if (ac) {
+        g_free(ac->alsa_name);
+        g_free(ac->friendly_name);
+        g_free(ac);
+    }
+}

--- a/modules/devices.c
+++ b/modules/devices.c
@@ -361,14 +361,37 @@ gchar *ldlinux_hwcaps() {
 	   g_free(cmd_line);
 	}
 	if (spawned && strlen(out)>=100) {
-	    gchar *t=supported;
-	    if(strstr(out,"x86-64-v1 (sup")) supported=g_strconcat(supported," x86-64-V1 ",NULL);
-	    if(strstr(out,"x86-64-v2 (sup")) supported=g_strconcat(supported," x86-64-V2 ",NULL);
-	    if(strstr(out,"x86-64-v3 (sup")) supported=g_strconcat(supported," x86-64-V3 ",NULL);
-	    if(strstr(out,"x86-64-v4 (sup")) supported=g_strconcat(supported," x86-64-V4 ",NULL);
-	    if(strstr(out,"x86-64-v5 (sup")) supported=g_strconcat(supported," x86-64-V5 ",NULL);//future
-	    if(strlen(supported)<1) supported=g_strconcat(supported," x86-64-V1 ",NULL);
-	    g_free(t);
+	    if(strstr(out,"x86-64-v1 (sup")) {
+	        gchar *old = supported;
+	        supported = g_strconcat(old, " x86-64-V1 ", NULL);
+	        g_free(old);
+	    }
+	    if(strstr(out,"x86-64-v2 (sup")) {
+	        gchar *old = supported;
+	        supported = g_strconcat(old, " x86-64-V2 ", NULL);
+	        g_free(old);
+	    }
+	    if(strstr(out,"x86-64-v3 (sup")) {
+	        gchar *old = supported;
+	        supported = g_strconcat(old, " x86-64-V3 ", NULL);
+	        g_free(old);
+	    }
+	    if(strstr(out,"x86-64-v4 (sup")) {
+	        gchar *old = supported;
+	        supported = g_strconcat(old, " x86-64-V4 ", NULL);
+	        g_free(old);
+	    }
+	    /* x86-64-v5 is not yet defined, reserved for future CPUs */
+	    if(strstr(out,"x86-64-v5 (sup")) {
+	        gchar *old = supported;
+	        supported = g_strconcat(old, " x86-64-V5 ", NULL);
+	        g_free(old);
+	    }
+	    if(strlen(supported)<1) {
+	        gchar *old = supported;
+	        supported = g_strconcat(old, " x86-64-V1 ", NULL);
+	        g_free(old);
+	    }
 	} else {
 	    gchar *t=supported;
 	    supported=g_strconcat(supported," x86-64-V1 ",NULL);

--- a/modules/devices/spd-decode.c
+++ b/modules/devices/spd-decode.c
@@ -1472,7 +1472,7 @@ GSList *spd_scan() {
 
             if (eeprom_list) {
 	        dimm_list = decode_dimms2(eeprom_list, driver->driver, driver->use_sysfs, driver->max_size);
-                g_slist_free(eeprom_list);
+                g_slist_free_full(eeprom_list, g_free);
                 eeprom_list = NULL;
             }
             if (dimm_list) break;

--- a/shell/shell.c
+++ b/shell/shell.c
@@ -3372,7 +3372,9 @@ gchar *key_mi_tag(const gchar *key) {
         }
         if (strlen(p)) {
             t = g_strdup(p);
-            *(strchr(t, '$')) = 0;
+            gchar *dollar = strchr(t, '$');
+            if (dollar) *dollar = 0;
+            else { g_free(t); return g_strdup(""); }
             return t;
         }
     }


### PR DESCRIPTION
**NOW ALL MEMLEAK ISSUE CLEARED!**

```shell
mkdir build-asan && cd build-asan
cmake .. \
  -DCMAKE_C_FLAGS="-fsanitize=address -g -O0" \
  -DCMAKE_CXX_FLAGS="-fsanitize=address -g -O0" \
  -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address"
make package -j$(nproc)
sudo apt install ./hardinfo2-*.deb
# CLI ALL FUNCTION
ASAN_OPTIONS=detect_leaks=1 hardinfo2 -f html -r
# GUI
ASAN_OPTIONS=detect_leaks=1 hardinfo2
```

All leaks come from GTK (libgtk-3), GLib (libglib-2.0), fontconfig, pcre2.

